### PR TITLE
Make extension compatible with EduLint 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EduLint for VS Code
 
-This extension runs the `python3 -m edulint <file>` shell command with the .py file you have just open in VS Code.
+This extension runs the `python3 -m edulint check <file>` shell command with the .py file you have just open in VS Code.
 
 This solution is temporary. I plan to migrate to [Language Server](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide) for a better DX.
 
@@ -11,12 +11,12 @@ You can either run the command `EduLint: Run Linting` from the Command Palette o
 ## Requirements
 
 - Python 3 (have `python3` command point to it)
-- EduLint as a Python package
+- EduLint v4.x as a Python package 
 
 You can install it by running the command:
 
 ```sh
-python3 -m pip install --user edulint
+python3 -m pip install --user edulint~=4.0
 ```
 
 ## Resources

--- a/extension.js
+++ b/extension.js
@@ -22,7 +22,7 @@ function activate(context) {
     }
 
     terminal.sendText(
-      `python3 -m edulint ${vscode.window.activeTextEditor.document.uri.path}`
+      `python3 -m edulint check ${vscode.window.activeTextEditor.document.uri.path}`
     )
   })
 


### PR DESCRIPTION
Hi Martin, 

EduLint changed the CLI interface in [v4.0.0](https://github.com/GiraffeReversed/edulint/releases/tag/v4.0.0).

This PR modifies this extension to add support for EduLint v4.x and drops support for v3.x.

If you're worried about compatibility on FI MU: computers there currently still have v3.x, but this will change next week (i.e. before the start of the semester).

